### PR TITLE
fix: ignore unknown logger properties

### DIFF
--- a/not-a-log.js
+++ b/not-a-log.js
@@ -6,7 +6,9 @@ const ts = new Transform({ transform: (chunk, _, cb) => cb(null, chunk) })
 const logger = new Console({ stdout: ts, stderr: ts, colorMode: false })
 const handler = {
   get (_, prop) {
-    return new Proxy(logger[prop], handler)
+    return Object.hasOwn(logger, prop)
+      ? new Proxy(logger[prop], handler)
+      : undefined;
   },
   apply (target, _, args) {
     target.apply(logger, args)


### PR DESCRIPTION
Fixes #2.

Skips creating a `new Proxy` if `prop` isn't a known property of `logger`. This seems to work:

* `Object.hasOwn(console, "log")` -> `true`
* `Object.hasOwn(console, "other")` -> `false`

Before this change, running `require("not-a-log").default.other` would crash with the error in #2. Now it returns `undefined`.